### PR TITLE
docs: update Mastra integration for latest observability API

### DIFF
--- a/integration/typescript/integrations/mastra.mdx
+++ b/integration/typescript/integrations/mastra.mdx
@@ -15,19 +15,19 @@ LangWatch integrates with Mastra through OpenTelemetry to capture traces from yo
 
 <CodeGroup>
 ```bash npm
-npm i langwatch @mastra/core @ai-sdk/openai @mastra/otel-exporter @mastra/loggers @mastra/libsql
+npm i langwatch @mastra/core @ai-sdk/openai @mastra/observability @mastra/otel-exporter @mastra/libsql
 ```
 
 ```bash pnpm
-pnpm add langwatch @mastra/core @ai-sdk/openai @mastra/otel-exporter @mastra/loggers @mastra/libsql
+pnpm add langwatch @mastra/core @ai-sdk/openai @mastra/observability @mastra/otel-exporter @mastra/libsql
 ```
 
 ```bash yarn
-yarn add langwatch @mastra/core @ai-sdk/openai @mastra/otel-exporter @mastra/loggers @mastra/libsql
+yarn add langwatch @mastra/core @ai-sdk/openai @mastra/observability @mastra/otel-exporter @mastra/libsql
 ```
 
 ```bash bun
-bun add langwatch @mastra/core @ai-sdk/openai @mastra/otel-exporter @mastra/loggers @mastra/libsql
+bun add langwatch @mastra/core @ai-sdk/openai @mastra/observability @mastra/otel-exporter @mastra/libsql
 ```
 </CodeGroup>
 
@@ -39,8 +39,8 @@ Configure your Mastra instance with OpenTelemetry exporter pointing to LangWatch
 import { Agent } from "@mastra/core/agent";
 import { Mastra } from "@mastra/core";
 import { openai } from "@ai-sdk/openai";
+import { Observability } from "@mastra/observability";
 import { OtelExporter } from "@mastra/otel-exporter";
-import { PinoLogger } from "@mastra/loggers";
 import { LibSQLStore } from "@mastra/libsql";
 
 export const mastra = new Mastra({
@@ -48,15 +48,13 @@ export const mastra = new Mastra({
     assistant: new Agent({
       name: "assistant",
       instructions: "You are a helpful assistant.",
-      model: openai("gpt-5"),
+      model: openai("gpt-4o"),
     }),
   },
-  // Storage is required for tracing in Mastra
-  storage: new LibSQLStore({ url: ":memory:" }),
-  logger: new PinoLogger({ name: "mastra", level: "info" }),
-  observability: {
+  storage: new LibSQLStore({ id: "mastra-storage", url: "file:./mastra.db" }),
+  observability: new Observability({
     configs: {
-      otel: {
+      langwatch: {
         serviceName: "<project_name>",
         exporters: [
           new OtelExporter({
@@ -70,7 +68,7 @@ export const mastra = new Mastra({
         ],
       },
     },
-  },
+  }),
 });
 ```
 


### PR DESCRIPTION
## Summary
- **Fixes broken observability**: Mastra now requires `new Observability({...})` from `@mastra/observability` instead of a plain config object. The old style silently disables all observability with a warning.
- **Adds `@mastra/observability`** as a required dependency (replaces `@mastra/loggers` which was unnecessary)
- **Adds required `id` param** to `LibSQLStore` constructor (now mandatory in latest `@mastra/libsql`)
- **Updates storage config** from `:memory:` to `file:./mastra.db` to match Mastra's current recommended pattern

## Test plan
- [ ] Verify the code example works with latest Mastra packages (`@mastra/core@1.15.0`, `@mastra/observability@1.5.1`, `@mastra/otel-exporter@1.0.8`)
- [ ] Confirm traces appear in LangWatch dashboard when running the example